### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Model Context Protocol (MCP) server for querying Dutch RDW (Rijksdienst voor het Wegverkeer) vehicle registration data. This server provides tools to look up vehicle information, fuel/emissions data, and search vehicles by brand and model using the official RDW open data API.
 
+<a href="https://glama.ai/mcp/servers/@jodur/RDW-MCP">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jodur/RDW-MCP/badge" alt="RDW Server MCP server" />
+</a>
+
 ## Quick Start
 
 1. **Install globally:**


### PR DESCRIPTION
This PR adds a badge for the [RDW MCP Server](https://glama.ai/mcp/servers/@jodur/RDW-MCP) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@jodur/RDW-MCP">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@jodur/RDW-MCP/badge" alt="RDW Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.